### PR TITLE
Add executor to return_data dictionary

### DIFF
--- a/adam/tests/batch_propagation_test.py
+++ b/adam/tests/batch_propagation_test.py
@@ -143,6 +143,7 @@ class BatchPropagationsTest(unittest.TestCase):
                 "end_time": "BBB",
                 "step_duration_sec": "0",
                 "propagator_uuid": "00000000-0000-0000-0000-000000000001",
+                "executor": "stk",
                 "opm": {
                     "header": {
                         "originator": "ADAM_User",


### PR DESCRIPTION
revise test_get_batch_propagation to include "executor" key. Travis is failing from KeyError.