### PR TITLE
Add "executor" to return_data

### DIFF
--- a/adam/tests/targeted_propagation_test.py
+++ b/adam/tests/targeted_propagation_test.py
@@ -196,6 +196,7 @@ class TargetedPropagationsTest(unittest.TestCase):
                 "end_time": "BBB",
                 "step_duration_sec": "0",
                 "propagator_uuid": "00000000-0000-0000-0000-000000000001",
+                "executor": "stk",
                 "opm": {
                     "header": {
                         "originator": "ADAM_User",


### PR DESCRIPTION
revise test_get_targeted_propagation to include "executor" key. Travis is failing from KeyError.