### PR TITLE
add - conda install tornado=5.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
 - conda update conda
+- conda install tornado=5.1.1
 - conda info -a
 - conda env create -n test-environment python=$TRAVIS_PYTHON_VERSION -f requirements.txt
 - source activate test-environment


### PR DESCRIPTION
Pin Tornado version to a previous version. The new 6.0 version does not work with nbconvert right now. Travis will fail on any jupyter notebook tests.