### PR TITLE
Return Ephemeris as Pandas Data Frame

### DIFF
--- a/adam/__init__.py
+++ b/adam/__init__.py
@@ -29,3 +29,4 @@ from adam.targeted_propagation import TargetedPropagation
 from adam.targeted_propagation import TargetedPropagations
 from adam.targeted_propagation import TargetingParams
 from adam.adam_processing_service import *
+from astro_utils import *

--- a/adam/__init__.py
+++ b/adam/__init__.py
@@ -29,4 +29,4 @@ from adam.targeted_propagation import TargetedPropagation
 from adam.targeted_propagation import TargetedPropagations
 from adam.targeted_propagation import TargetingParams
 from adam.adam_processing_service import *
-from astro_utils import *
+from adam.astro_utils import *

--- a/adam/adam_processing_service.py
+++ b/adam/adam_processing_service.py
@@ -3,7 +3,7 @@ import time
 import urllib
 from enum import Enum
 
-from adam import PropagationParams, OpmParams
+from adam import PropagationParams, OpmParams, stk
 
 
 class ApsResults:
@@ -173,7 +173,7 @@ class BatchPropagationResults(ApsResults):
             return 0
         return len(ephemeris_objects)
 
-    def get_result_ephemeris(self, run_number, force_update=False):
+    def get_result_raw_ephemeris(self, run_number, force_update=False):
         """Get an ephemeris for a particular run in the batch.
 
         Args:
@@ -190,9 +190,23 @@ class BatchPropagationResults(ApsResults):
         if not base_url.endswith('/'):
             base_url = base_url + '/'
         url = urllib.parse.urljoin(base_url, ephemeris_resource_name)
-        print(url)
         with urllib.request.urlopen(url) as response:
             return response.read().decode('utf-8')
+
+    def get_result_ephemeris(self, run_number, force_update=False):
+        """Get an ephemeris for a particular run in the batch as a Panda DataFrame
+
+        Args:
+            force_update (boolean): whether the request should be re-executed.
+
+        Returns:
+            ephemeris: Ephemeris from file as a Panda DataFrame
+        """
+
+        ephemeris_text = self.get_result_raw_ephemeris(run_number, force_update)
+        ephemeris = stk.io.ephemeris_file_data_to_dataframe(ephemeris_text.splitlines())
+        return ephemeris
+
 
     def __update_results(self, force_update):
         if force_update or self._detailedOutputs is None:
@@ -221,6 +235,21 @@ class AdamProcessingService:
         """
         code, response = self._rest.get(f'/projects/{project}/jobs')
         return response
+
+    def get_job_results(self, project, job_id):
+        """Get the job results for a specific job for a specific project.
+
+        Args:
+            project (str): The workspace (project) id.
+            job_id (str): The job id.
+
+        Returns:
+            result (ApsResults): a result object that can be used to query for data about the submitted job
+        """
+        results_processor = ApsRestServiceResultsProcessor(self._rest, project)
+
+        return BatchPropagationResults(results_processor, job_id)
+
 
     def execute_batch_propagation(self,
                                   project,

--- a/adam/adam_processing_service.py
+++ b/adam/adam_processing_service.py
@@ -200,13 +200,12 @@ class BatchPropagationResults(ApsResults):
             force_update (boolean): whether the request should be re-executed.
 
         Returns:
-            ephemeris: Ephemeris from file as a Panda DataFrame
+            ephemeris: Ephemeris from file as a Pandas DataFrame
         """
 
         ephemeris_text = self.get_result_raw_ephemeris(run_number, force_update)
         ephemeris = stk.io.ephemeris_file_data_to_dataframe(ephemeris_text.splitlines())
         return ephemeris
-
 
     def __update_results(self, force_update):
         if force_update or self._detailedOutputs is None:

--- a/adam/astro_utils.py
+++ b/adam/astro_utils.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+
+JPL_OBLIQUITY = np.deg2rad(84381.448 / 3600.0)
+
+def icrf_to_jpl_ecliptic(x, y, z, vx, vy, vz):
+    return _apply_x_rotation(JPL_OBLIQUITY, x, y, z, vx, vy, vz)
+
+
+def jpl_ecliptic_to_icrf(x, y, z, vx, vy, vz):
+    return _apply_x_rotation(-JPL_OBLIQUITY, x, y, z, vx, vy, vz)
+
+
+def _apply_x_rotation(phi, x0, y0, z0, vx0, vy0, vz0):
+    x = x0
+    y = y0 * np.cos(phi) + z0 * np.sin(phi)
+    z = -y0 * np.sin(phi) + z0 * np.cos(phi)
+    vx = vx0
+    vy = vy0 * np.cos(phi) + vz0 * np.sin(phi)
+    vz = -vy0 * np.sin(phi) + vz0 * np.cos(phi)
+    return [x, y, z, vx, vy, vz]

--- a/adam/tests/astro_utils_test.py
+++ b/adam/tests/astro_utils_test.py
@@ -1,0 +1,39 @@
+import unittest
+import astro_utils
+
+JPL_ECLIPTIC_X = -3.027985514061421E+08
+JPL_ECLIPTIC_Y = 2.855686074583623E+08
+JPL_ECLIPTIC_Z = 1.678012767460957E+07
+JPL_ECLIPTIC_VX = -1.238827604421024E+01
+JPL_ECLIPTIC_VY = -1.047525790511110E+01
+JPL_ECLIPTIC_VZ = -1.218174336421540E+00
+
+ICRF_X = -3.027985514061421E+08
+ICRF_Y = 2.553293233705423E+08
+ICRF_Z = 1.289881346389093E+08
+ICRF_VX = -1.238827604421024E+01
+ICRF_VY = -9.126299300516822E+00
+ICRF_VZ = -5.284471399288181E+00
+
+
+class AstroUtilsTest(unittest.TestCase):
+
+    def test_icrf_to_ecliptic(self):
+        ecliptic_pos_vel = astro_utils.icrf_to_jpl_ecliptic(ICRF_X, ICRF_Y, ICRF_Z, ICRF_VX, ICRF_VY, ICRF_VZ)
+        self.assertAlmostEqual(JPL_ECLIPTIC_X, ecliptic_pos_vel[0],8)
+        self.assertAlmostEqual(JPL_ECLIPTIC_Y, ecliptic_pos_vel[1],6)
+        self.assertAlmostEqual(JPL_ECLIPTIC_Z, ecliptic_pos_vel[2],6)
+
+        self.assertAlmostEqual(JPL_ECLIPTIC_VX, ecliptic_pos_vel[3],15)
+        self.assertAlmostEqual(JPL_ECLIPTIC_VY, ecliptic_pos_vel[4],14)
+        self.assertAlmostEqual(JPL_ECLIPTIC_VZ, ecliptic_pos_vel[5],14)
+
+    def test_ecliptic_to_icrf(self):
+        icrf_pos_vel = astro_utils.jpl_ecliptic_to_icrf(JPL_ECLIPTIC_X, JPL_ECLIPTIC_Y, JPL_ECLIPTIC_Z, JPL_ECLIPTIC_VX, JPL_ECLIPTIC_VY, JPL_ECLIPTIC_VZ)
+        self.assertAlmostEqual(ICRF_X, icrf_pos_vel[0],8)
+        self.assertAlmostEqual(ICRF_Y, icrf_pos_vel[1],6)
+        self.assertAlmostEqual(ICRF_Z, icrf_pos_vel[2],6)
+
+        self.assertAlmostEqual(ICRF_VX, icrf_pos_vel[3],15)
+        self.assertAlmostEqual(ICRF_VY, icrf_pos_vel[4],14)
+        self.assertAlmostEqual(ICRF_VZ, icrf_pos_vel[5],14)

--- a/adam/tests/stk/io_test.py
+++ b/adam/tests/stk/io_test.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+
+import numpy
+from stk.io import ephemeris_file_data_to_dataframe
+import unittest
+
+STK_EPHEM_TEXT = '''
+stk.v.11.0
+BEGIN Ephemeris
+ScenarioEpoch 30 Dec 2008 01:14:17.620000
+CentralBody SUN
+CoordinateSystem ICRF
+InterpolationMethod HERMITE
+InterpolationOrder 5
+NumberOfEphemerisPoints 1097
+
+EphemerisTimePosVel
+0.000000000000e+00 9.361973576452e+10 -1.811359048452e+11 -8.103280027661e+10 1.766818009358e+04 1.391375015366e+04 5.222453970115e+03
+8.640000000000e+04 9.514184241432e+10 -1.799252621642e+11 -8.057777871925e+10 1.756537425528e+04 1.411039477722e+04 5.310472158010e+03
+1.727990000000e+05 9.665496366388e+10 -1.786976273177e+11 -8.011514735716e+10 1.746018049128e+04 1.430708487060e+04 5.398605983415e+03
+2.591990000000e+05 9.815889209618e+10 -1.774529970188e+11 -7.964489642865e+10 1.735257327800e+04 1.450380549577e+04 5.486850102770e+03
+
+
+END Ephemeris
+'''
+
+class StkIoTest(unittest.TestCase):
+
+    def test_ephemeris_file_data_to_dataframe(self):
+        ephemeris = ephemeris_file_data_to_dataframe(STK_EPHEM_TEXT.splitlines())
+        self.assertEqual((4,7), ephemeris.shape)
+        self.assertEquals(numpy.datetime64('2008-12-30T01:14:17.62'), ephemeris.values[0][0])
+        self.assertAlmostEqual(9.361973576452e+7, ephemeris.values[0][1], 5)
+        self.assertAlmostEqual(-198421940.32336992, ephemeris.values[0][2], 5)
+        self.assertAlmostEqual(-2294415.6265469044, ephemeris.values[0][3], 5)
+        self.assertAlmostEqual(1.766818009358e+01, ephemeris.values[0][4], 11)
+        self.assertAlmostEqual(14.842989069313047, ephemeris.values[0][5], 11)
+        self.assertAlmostEqual(-0.7430641269076066, ephemeris.values[0][6], 11)
+        self.assertEqual(numpy.datetime64('2009-01-02T01:14:16.62'), ephemeris.values[3][0])

--- a/demos/Loading Run Data Example.ipynb
+++ b/demos/Loading Run Data Example.ipynb
@@ -1,0 +1,391 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Illustrate Pulling Run Data From ADAM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from adam import Batch\n",
+    "from adam import Batches\n",
+    "from adam import BatchRunManager\n",
+    "from adam import PropagationParams\n",
+    "from adam import OpmParams\n",
+    "from adam import ConfigManager\n",
+    "from adam import Projects\n",
+    "from adam import RestRequests\n",
+    "from adam import AuthenticatingRestProxy\n",
+    "from adam import AdamProcessingService\n",
+    "from adam import ApsRestServiceResultsProcessor\n",
+    "from adam import BatchPropagationResults\n",
+    "import matplotlib.pyplot as plt\n",
+    "import time\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This sets up authenticated access to the server. It needs to be done before pretty much everything you want to do with ADAM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ConfigManager loads the config set up via adamctl.\n",
+    "# See the README at https://github.com/B612-Asteroid-Institute/adam_home/blob/master/README.md\n",
+    "config = ConfigManager().get_config('adam_dev')\n",
+    "auth_rest = AuthenticatingRestProxy(RestRequests(config['url']), config['token'])\n",
+    "aps = AdamProcessingService(auth_rest)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting Jobs List"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is possible to query the service for all the jobs for your project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Completed Jobs:2\n"
+     ]
+    }
+   ],
+   "source": [
+    "jobs = aps.get_jobs(config['workspace'])\n",
+    "completed_jobs = [j for j in jobs['items'] if j['status'] == 'COMPLETED']\n",
+    "print(f\"Completed Jobs:{len(completed_jobs)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Job Results\n",
+    "\n",
+    "### Get first job (assuming at leastone job) and its inputs JSON"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"opm\": {\"header\": {\"comments\": [], \"originator\": \"ADAM_User\", \"creation_date\": \"2020-10-07 15:40:29.414165\"}, \"metadata\": {\"comments\": [\"Cartesian coordinate system\"], \"object_id\": \"001\", \"ref_frame\": \"ICRF\", \"center_name\": \"SUN\", \"object_name\": \"dummy\", \"time_system\": \"UTC\", \"ref_frame_epoch\": null}, \"keplerian\": null, \"maneuvers\": [], \"spacecraft\": {\"mass\": 1000, \"comments\": [], \"drag_area\": 20, \"drag_coeff\": 2.2, \"solar_rad_area\": 20, \"solar_rad_coeff\": 1}, \"adam_fields\": [{\"key\": \"INITIAL_PERTURBATION\", \"value\": \"None\"}, {\"key\": \"HYPERCUBE\", \"value\": \"None\"}], \"state_vector\": {\"x\": 130347560.13690618, \"y\": -74407287.6018632, \"z\": -35247598.54147063, \"epoch\": \"2017-10-04T00:00:00Z\", \"x_dot\": 23.935241263310683, \"y_dot\": 27.146279819258535, \"z_dot\": 10.346605942591514, \"comments\": []}, \"ccsds_opm_vers\": \"2.0\", \"cartesianCovariance\": {\"cx_x\": 0.0003331349476038534, \"cy_x\": 0.0004618927349220216, \"cy_y\": 0.0006782421679971363, \"cz_x\": -0.0003070007847730449, \"cz_y\": -0.0004221234189514228, \"cz_z\": 0.0003231931992380369, \"epoch\": null, \"comments\": [], \"cx_dot_x\": -0.000000334936503392263, \"cx_dot_y\": -0.0000004686084221046758, \"cx_dot_z\": 0.0000002484949578400095, \"cy_dot_x\": -0.0000002211832501084875, \"cy_dot_y\": -0.0000002864186892102733, \"cy_dot_z\": 0.0000001798098699846038, \"cz_dot_x\": -0.0000003041346050686871, \"cz_dot_y\": -0.0000004989496988610662, \"cz_dot_z\": 0.0000003540310904497689, \"cx_dot_x_dot\": 0.000000000429602280558729, \"cy_dot_x_dot\": 0.00000000026088992016860156, \"cy_dot_y_dot\": 0.0000000001767514756338532, \"cz_dot_x_dot\": 0.000000000186926319295459, \"cz_dot_y_dot\": 0.00000000010088625862406949, \"cz_dot_z_dot\": 0.0000000006224444338635501, \"cov_ref_frame\": null}, \"keplerianCovariance\": null}, \"end_time\": \"2017-10-11T00:00:00Z\", \"executor\": null, \"start_time\": \"2017-10-04T00:00:00Z\", \"stopOnImpact\": true, \"cartesianSigma\": null, \"keplerianSigma\": null, \"monteCarloDraws\": 10, \"propagationType\": \"MONTE_CARLO\", \"propagator_uuid\": \"00000000-0000-0000-0000-000000000001\", \"step_duration_sec\": 86400, \"stopOnCloseApproach\": false, \"enableLogCloseApproaches\": true, \"stopOnImpactDistanceMeters\": 500000, \"stopOnCloseApproachAfterEpoch\": \"2017-10-11T00:00:00Z\", \"closeApproachRadiusFromTargetMeters\": 7000000000}\n"
+     ]
+    }
+   ],
+   "source": [
+    "job = completed_jobs[0]\n",
+    "print(job['inputParametersJson'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get Job Result Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_run = aps.get_job_results(config['workspace'], job['uuid'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Confirm Job Completed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'COMPLETED'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch_run.check_status()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get Number of Runs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# Runs: 11\n"
+     ]
+    }
+   ],
+   "source": [
+    "runs_count = batch_run.get_result_ephemeris_count()\n",
+    "print(f'# Runs: {runs_count}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get Summary Statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'misses': 11, 'close_approach': 0, 'impacts': 0, 'pc': 0.0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "stats = batch_run.get_summary()\n",
+    "print(stats)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get Ephemeris and Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Timestamp('2017-10-04 00:00:00') 130347560.1335 -82288041.15372841\n",
+      " -2741520.150300201 23.93524884363 29.02186659761898 -1.3053774191565335]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='Epoch', ylabel='Velocity(km/s)'>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEpCAYAAAC9enRxAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAge0lEQVR4nO3deZhcdZ3v8fen96xICEskCYlORlkExFzUuTiKigYeERkHDYzKoHdyieIIrmEcB4a53ituFxE1N1wZwIer4AgCV1a5AvIoaoIsQVaRpWUJJChblk739/5Rpzqnq6u6q05X9amq/ryep546dc6vzvmmaL7f3/mdTRGBmZlZrTryDsDMzFqTC4iZmWXiAmJmZpm4gJiZWSYuIGZmlokLiJmZZdK2BUTSeZI2SFpfRduFkn4m6beS7pR0xGTEaGbWytq2gADnA8uqbPvPwCUR8VpgOfDtRgVlZtYu2raARMTNwKb0PEmvlHSNpHWSfi7p1cXmwOxkeifg8UkM1cysJXXlHcAkWwOcGBEPSHo9hT2NtwKnA9dJ+jgwA3h7fiGambWGKVNAJM0E/gr4oaTi7N7k/Vjg/Ij4mqQ3At+TtF9EDOUQqplZS5gyBYTCcN2fIuLAMss+QnK8JCJ+KakPmAtsmLzwzMxaS9seAykVEc8Bf5B0DIAKDkgWPwq8LZm/N9AHPJ1LoGZmLULtejdeSd8H3kJhT+Ip4DTg/wHfAeYB3cAPIuIMSfsA5wIzKRxQ/2xEXJdH3GZmraJtC4iZmTXWlBnCMjOz+nIBMTOzTNryLKy5c+fGokWL8g7DzKxlrFu37pmI2LWW7+RaQCSdB7wL2BAR+5VZ/hbgcuAPyaxLI+KM8da7aNEi1q5dW8dIzczam6RHav1O3nsg5wPnABeO0ebnEfGuyQnHzMyqlesxkHL3qzIzs9bQCgfR3yjpDklXS9o372DMzKwg7yGs8dwG7BURLyTP6PgxsKRcQ0krgBUACxcunLQAzcymqqbeA4mI5yLihWT6KqBb0twKbddExNKIWLrrrjWdSGBmZhk0dQGRtIeSW+dKOphCvBvzjcrMzCD/03iH71clqZ/C/aq6ASJiNfC3wEpJ24HNwPLwvVfMzJpCrgUkIo4dZ/k5FE7zNTOzxOBQsHX7IFsGhobftwwMsnX7yPfi9NYR84ZGfXfr9sFMcTT7QXQzs6YVEWMm5okm9S0DQ2zZPsjW5PPW5PPAYPaBmA5BX3cnvV0dI96zcAExs7YwOBQjEnRpYi4k4pHLSttuSSXpraXfHxjcsXxgkC3bh9i2fWIPLe3r7iibzPu6OpnR28WcGZ30dnfQ19VJX3cHvaPek/Yl6+jtrtS+k+5OkXoq6zCdUnv8LiBmVnfpZL4l1fPeMlDoeW8p01MvTdLlevFj9dYn0ivv7lTZZFtM8LP6ulPJurBsR2If3b60bfo7xc89nR1lE3krcQExa3OlwyxbUgl8dFIe3UMv9sy3DKR73yO/X/jOjuIwkWTe09UxIgH3pZL19J4u5sxIJfCkt57upY9K4OO06e3qoKuzqU9IbVouIGaTbKze+ajpdC+8QvvNAzuGXcoNzWydwDBLV4fK9rCL8142rXvUsEkxqe9oW0zUlddT7Mn3dnXQ0dHavfKpxAXEprztg0NsHpF4R/a+Nw8n7EIC3zpGki/25DdvKzN/gr1ziZLEPLKnPWdGz+jlJcMspd8p9MxLErp75lYlFxBrOkNDhSGXEYk7SeTp8fPRSXqwTNKvlNB3TG8fypbQi2ezjEi6STKe1t3J7Gnd5ZN0md556Xr6Str3JgdMW33M3NqLC4hVZWAwlZS37RguKSTmQjIfTtSpoZbh4ZXku+mefun4enFdWc9sKe2hT0sl9L6u0Ql9WvfIRL6jfflEPq175Lh7pbNZzKYKF5AWFRFsGxwalYw3pxL11pKEXZq8iwk73XsvtikWhOI6BzP20ns6O0aNdxcT9U7Te9ijtFfe0zliyGVa6ns7kv6OojCtxz10s7y4gNRRRDAwGIUe9bYdybdSUt+8rcy8CkMx6Z58cV7GnD6iR12a2Gf1dY9I+NNKknVvmXmlwzDF5b1dnXT6gKhZ25oSBaR41svmpNddGGopDJ0Uk3ilpJ0uBOnkXSnZZ+mpS+xI5l2FXvi0VDLeeXr3iMQ9MvGP7qmPTOQjl7uXbmb10pYF5L4nn+fgL/50uNe+bTDbmHrxbJVp3Unvu6tjeMhk11ndw2Pi6WRf2i7dQ59WktindXfS19MeFxSZ2dTTlgVkek8nb9t7N3pTY+TTenaMvY9M+B072hXn+Xx0M7NxtWUBWTBnOv/jb/bPOwwzs7bmq4TMzCwTFxAzM8vEBcTMzDJxATEzs0xcQMzMLBMXEDMzy8QFxMzMMnEBMTOzTFxAzMwsExcQMzPLxAXEzMwycQExM7NMXEDMzCwTFxAzM8vEBcTMzDJxATEzs0xcQMzMLBMXEDMzy8QFxMzMMnEBMTOzTHItIJLOk7RB0voKyyXpbEkPSrpT0kGTHaOZmZWX9x7I+cCyMZYfDixJXiuA70xCTGZmVoVcC0hE3AxsGqPJUcCFUXAr8DJJ8yYnOjMzG0veeyDj2RN4LPW5P5lnZmY5a/YCojLzomxDaYWktZLWPv300w0Oy8zMmr2A9AMLUp/nA4+XaxgRayJiaUQs3XXXXSclODOzqazZC8gVwIeSs7HeAPw5Ip7IOygzM4OuPDcu6fvAW4C5kvqB04BugIhYDVwFHAE8CLwEnJBPpGZmVirXAhIRx46zPICPTVI4ZmZWg2YfwjIzsyblAmJmZpm4gJiZWSYuIGZmlokLiJmZZeICYmZmmbiAmJlZJi4gZmaWiQuImZll4gJiZmaZuICYmVkmLiBmZpaJC4iZmWXiAmJmZpm4gJiZWSYuIGZmlokLiJmZZeICYmZmmbiAmJlZJi4gZmaWiQuImZll4gJiZmaZuICYmVkmLiBmZpaJC4iZmWXiAmJmZpm4gJiZWSZdtTSWtDPwcmAz8HBEDDUkKjMza3rjFhBJOwEfA44FeoCngT5gd0m3At+OiJ81NEozM2s61eyB/AdwIfCmiPhTeoGk1wEflPSKiPhuA+IzM7MmNW4BiYjDxli2DlhX14jMzKwl1HoMZH9gUfp7EXFpnWMyM7MWUHUBkXQesD9wN1A8eB6AC4iZGTAwMEB/fz9btmzJO5SK+vr6mD9/Pt3d3RNeVy17IG+IiH0mvEUzszbV39/PrFmzWLRoEZLyDmeUiGDjxo309/ezePHiCa+vlutAfinJBcTMrIItW7awyy67NGXxAJDELrvsUrc9pFoKyAUUish9ku6UdJekOyeycUnLkvU9KGlVmeVvkfRnSbcnr3+ZyPbMzBqtWYtHUT3jq6WAnAd8EFgGHAm8K3nPRFIn8C3gcGAf4NgKezg/j4gDk9cZWbdnZtbuHnvsMRYvXsymTZsAePbZZ1m8eDGPPPJIQ7ZXSwF5NCKuiIg/RMQjxdcEtn0w8GBEPBQR24AfAEdNYH1mZlPaggULWLlyJatWFQZ0Vq1axYoVK9hrr70asr1aDqLfK+n/AFcCW4szJ3Aa757AY6nP/cDry7R7o6Q7gMeBT0fE3Rm3Z2bW9k455RRe97rXcdZZZ3HLLbfwzW9+s2HbqqWATKNQON6RmjeR03jLDcRFyefbgL0i4gVJRwA/BpaUXZm0AlgBsHDhwowhmZnVx79eeTe/e/y5uq5zn5fP5rQj9x2zTXd3N1/5yldYtmwZ1113HT09PXWNIa2WAvKpiNiUniFpIueB9QMLUp/nU9jLGBYRz6Wmr5L0bUlzI+KZ0pVFxBpgDcDSpUtLC5GZ2ZRx9dVXM2/ePNavX89hh1W8mciE1VJArpR0eDGpS9ob+CGwX8Zt/wZYkhShPwLLgePSDSTtATwVESHpYArHbDZm3J6Z2aQZb0+hUW6//Xauv/56br31Vg455BCWL1/OvHnzGrKtWg6i/3cKRWRmchPF/wA+kHXDEbEdOAm4FrgHuCQi7pZ0oqQTk2Z/C6xPjoGcDSyPCO9dmJmVERGsXLmSs846i4ULF/KZz3yGT3/60w3bXtV7IBHxE0ndwHXALOA9EfHARDYeEVcBV5XMW52aPgc4ZyLbMDObKs4991wWLlw4PGz10Y9+lPPPP5+bbrqJN7/5zXXfXjXPA/kmIw9uzwYeAj4uiYj4x7pHZWZmNVuxYgUrVqwY/tzZ2cm6dY27YXo1eyBrSz779u1mZlbV80AumIxAzMystYx7EF3SlZKOTI5/lC57haQzJH24MeGZmVmzqmYI6x+ATwJnSdrEjmeiLwYeBM6JiMsbF6KZmTWjaoawngQ+C3xW0iJgHrAZuD8iXmpseGZm1qxqeqRtRDwMPNyQSMzMrKVUfSGhpPdKeiB5Psdzkp6XVN8bvZiZWSYRwSGHHMLVV189PO+SSy5h2bJlDdtmLXsgZwJHRsQ9jQrGzMyykcTq1as55phjOPTQQxkcHOTzn/8811xzTcO2WUsBecrFw8ysee23334ceeSRnHnmmbz44ot86EMf4pWvfGXDtldLAVkr6WIKt1Svx/NAzMza19Wr4Mm76rvOPV4Dh39pzCannXYaBx10ED09PaxdW3odeH3VUkBmAy9Rv+eBmJlZnc2YMYP3v//9zJw5k97e3oZuq5abKZ7QyEDMzNrKOHsKjdTR0UFHRy03W8+4nWobSpov6TJJGyQ9JelHkuY3MjgzM2tetZSofweuAF5O4XnmVybzzMxsCqrlGMiuEZEuGOdLOrnO8ZiZ2QSdfvrpk7KdWvZAnpH0AUmdyesD+PGyZmZTVi0F5MPA+4AngScoPG7Wd+E1M5uiajkL61Hg3Q2MxczMWkg1j7T9bER8ucyjbQH8SFszsymqmj2Q4u1LGntJo5mZtZRqngdyZTL5UkT8ML1M0jENicrMzJpeLQfRT61ynpmZ5eCyyy7jwAMPHPHq6OgYcYv3eqrmGMjhwBHAnpLOTi2aDWxvSFRmZlazo48+mqOPPnr485o1a7jooot45zvf2ZDtVXMM5HEKxz/eDaxLzX8eOKURQZmZ2cTcf//9nHHGGfziF79o2H2xqjkGcgdwh6SLIsJ7HGZmVTjz12dy76Z767rOV895NZ87+HPjthsYGOC4447jq1/9KgsXLqxrDGnVDGFdEhHvA34rKX0ar4CIiP0bFp2ZmdXsC1/4Avvuuy/Lly9v6HaqGcL6RPL+rkYGYmbWTqrZU2iEG2+8kR/96EfcdtttDd/WuANjEfFEMvkM8FhEPAL0AgdQOD5iZmZN4Nlnn+WEE07gwgsvZNasWQ3fXi1HVm4G+iTtCdwAnACc34igzMysdqtXr2bDhg2sXLlyxKm8F198cUO2V8vt3BURL0n6CPDN5PYmv21IVGZmVrNTTz2VU0+dvMvzatkDkaQ3An8H/CSZV0sBMjOzNlJLATmZwpXnl0XE3ZJeAfysIVGZmVnTq+V27jcBN0maJWlmRDwE+E68ZmZTVNV7IJJekxzzWA/8TtI6Sfs2LjQzs9YTMeqpF02lnvHVMoT1v4BPRsReEbEQ+BRw7kQ2LmmZpPskPShpVZnlknR2svxOSQdNZHtmZo3U19fHxo0bm7aIRAQbN26kr6+vLuur5SD4jIgYPuYRETdKmpF1w5I6gW8BhwH9wG8kXRERv0s1OxxYkrxeD3wneTczazrz58+nv7+fp59+Ou9QKurr62P+/Pl1WVctBeQhSV8Avpd8/gDwhwls+2DgweRYCpJ+ABwFpAvIUcCFUSjnt0p6maR5qYsbzcyaRnd3N4sXL847jElTyxDWh4FdgUuT11wKFxNmtSfwWOpzfzKv1jZmZpaDam6m2AecCPwFcBfwqYgYqMO2VWZe6cBhNW0KDaUVwAqgoXefNDOzgmqGsC4ABoCfUzgmsTeFa0Imqh9YkPo8n9H31qqmDQARsQZYA7BgnwXx9XVfR0n9GX7XyM9FpfPTn4fbDr+Nvc7i5+F1p+ZX+m65tuO1G9WmUttx2pX7LWr+vSq1r/Y3q+NvXNV6q/jtxtv2RH6TzH+XE1jnRH6Lan6PcdvV8e9z3O1k/Duy2lVTQPaJiNcASPou8Os6bfs3wBJJi4E/AsuB40raXAGclBwfeT3w52qOf2zasomLfncRAJHssBTfd7yNnF88ayLK7+CYWZtrRFGa9II+wfXWqpoCMjxcFRHb61W1k3WdBFwLdALnJVe4n5gsXw1cReFxug8CL1HlMZe95+zN2g+urUeMhfcKRaaWolR6Wt946xzVPr2ucYreeHFXbJeKs9aCW7F9tf++yV7vGL/JuJ2LGjsh5f4OsnZsyrWv128xbrsq/jZr/T1qalfLf7uJ/s6pf2Mz/W02ar1BcC3XUiuNd76ypEHgxeJHYBqFZK7CtmN2zVttsKVLl8batRMvIGZmU4WkdRGxtJbvVPNI287sIZmZWbtqzJPWzcys7bmAmJlZJi4gZmaWiQuImZll4gJiZmaZuICYmVkmLiBmZpaJC4iZmWXiAmJmZpm4gJiZWSYuIGZmlokLiJmZZeICYmZmmbiAmJlZJi4gZmaWiQuImZll4gJiZmaZuICYmVkmLiBmZpaJC4iZmWXiAmJmZpm4gJiZWSYuIGZmlokLiJmZZeICYmZmmbiAmJlZJi4gZmaWiQuImZll4gJiZmaZuICYmVkmLiBmZpaJC4iZmWXiAmJmZpm4gJiZWSZdeWxU0hzgYmAR8DDwvoh4tky7h4HngUFge0QsnbwozcxsLHntgawCboiIJcANyedKDo2IA108zMyaS14F5CjggmT6AuA9OcVhZmYZ5VVAdo+IJwCS990qtAvgOknrJK2YtOjMzGxcDTsGIumnwB5lFn2+htX854h4XNJuwPWS7o2ImytsbwWwAmDhwoU1x2tmZrVpWAGJiLdXWibpKUnzIuIJSfOADRXW8XjyvkHSZcDBQNkCEhFrgDUAS5cujYnGb2ZmY8trCOsK4Phk+njg8tIGkmZImlWcBt4BrJ+0CM3MbEx5FZAvAYdJegA4LPmMpJdLuippsztwi6Q7gF8DP4mIa3KJ1szMRsnlOpCI2Ai8rcz8x4EjkumHgAMmOTQzM6uSr0Q3M7NMXEDMzCwTFxAzM8vEBcTMzDJxATEzs0xcQMzMLJNcTuM1M7M6ioCBl2Dbi7DtBdj6QjL9Imx7fsf01tT0theSV/I5AxcQM7PJFAHbt1af3LemE33J+9bUZ6q8g1NHF/TMLLx6Z0LPjMIrAxcQM7OxbN82urc+opc/VnIvs2zrCxCD1W1bHTuSfTHR986CWfOSz6XL0p9T0+n5Xb3lt/X3qvmncQExs/YxOFDSky/p5ZdN7mWGc9LLhwaq3346mRcT+PRdYOe9yiT8dHIvs6x3JnT1gWpP7JPFBcTM8jE4MEavvjSpV0jupe0Gt1W//e7po5P5tJ1hp/mj55fryZcm/e7p0DG1zktyATGz8Q0P47w4foIvNz5fbo+glmTfNW10Au+bDbNfPsYQzgzomTUy2femk31n436vKcIFxKzdDB+grZTUy8wvWwhSewW1DONUTPbzyo/Pl0vwpT1/J/um5AJilpcI2L6lcrIfdWbOGO3Sn2tJ9t3TR/fW+14Gs/esMEY/o0yCLykETvZThguIWTWGhkaeZ19VUq/U2099jqHqYyjXY58+B162oDDdPT3V6y+X7JMzeIrTHsaxCXIBsfYzuB0Gqk3w47QrjuMP1HChlTpKxt6TJD5zj/JJvdx0aa+/a9qUO0Brzc8FxPIz4oKqapL8WAk/9Xlwa/UxpC+q6pkBPcmZObPnVxi6qSL5N/mpl2b14gJi1RkaTA3hlEvs5YZ3qkj41V5QBSXj9ZUOzo6V4GfsGOopTnf1NO43M2tzLiDtplKvftwhnZfGTvjbN1cfw/DVs6VDOLtV34svnfZ4vVnTcQHJ06ix+jGS/LgHcFPLa+nVF0+57Jk+MmGPSPYzoHu8IZzpO3r33dM8hGM2BbiAVCN9Bk7ZnnxJ732gtDefHuLJOFavzgq9+j3KF4DS6fSwjU+5NLM6aM8CMrQdnn2kyh58uTYlxaGWM3CgfG+9dKy+u1zCn56cijlr9Pc7e9yrN7Om0p4F5Mm74Bv7j9+uq6/8EM30uRV69eWGckp69j7d0symiPYsIDvNh6O+OPbwTfd06GzPf76Z2WRozww6Y1d47QfyjsLMrK15rMXMzDJxATEzs0xcQMzMLBMXEDMzy8QFxMzMMnEBMTOzTFxAzMwsExcQMzPLRBGRdwx1J+l54L6848hoJ+DPeQcxAY4/X44/X60c/6siYlYtX2jPK9HhvohYmncQWUhaExEr8o4jK8efL8efr1aOX9LaWr/jIazmc2XeAUyQ48+X489Xq8dfk3YdwlrbqnsgZmZ5yJI323UPZE3eAZiZtZia82ZbFpCIaJkCImmZpPskPShpVTLvdEl/lHR78joi7zjLKRd7Mv/jyfy7JX05zxjHUuG3vzj1uz8s6facw6yoQvwHSro1iX+tpIPzjrOSCvEfIOmXku6SdKWk2XnHWY6k8yRtkLQ+NW+OpOslPZC875xnjLXKlDcjwq+cXkAn8HvgFUAPcAewD3A68Om848sY+6HAT4HepN1uecdaS/wlbb4G/Evesdb4+18HHJ60OQK4Me9Ya4z/N8CbkzYfBv4t71grxP/XwEHA+tS8LwOrkulVwJl5x9noV8vvgVTqBSfLPi0pJM3NK75xHAw8GBEPRcQ24AfAUTnHVK1Ksa8EvhQRWwEiYkOOMY5lzN9ekoD3Ad/PKb7xVIo/gGKvfSfg8ZziG0+l+F8F3Jy0uR54b07xjSkibgY2lcw+Crggmb4AeM9kxlSLCntQxySjBkOSqjoW0tIFRFIn8C3gcAq9l2Ml7ZMsWwAcBjyaX4Tj2hN4LPW5P5kHcJKkO5P/0M24K1wp9r8E3iTpV5JukvSfcolufGP99gBvAp6KiAcmNarqVYr/ZOArkh4DvgqcOvmhVaVS/OuBdyfzjgEWTHJcE7F7RDwBkLzvlnM8YzkfWFYybz3wN+wo4ONq6QLC2L3I/wl8lkKPrFmpzLwAvgO8EjgQeILCUEqzqRR7F7Az8AbgM8AlSW++2VSKv+hYmnfvAyrHvxI4JSIWAKcA353UqKpXKf4PAx+TtA6YBWyb1KimiHJ7UBFxT0TUdAF2qxeQsr0YSe8G/hgRd+QTVtX6GdnDmg88HhFPRcRgRAwB51IolM2mbOzJ/Euj4NfAENCMQ4iV4kdSF4We2MU5xFWtSvEfD1yazPshzfm3A5X/9u+NiHdExOsoFPDf5xJdNk9JmgeQvDfr8G3dtHoBKdeL6QU+D/zLJMeSxW+AJZIWS+oBlgNXFP8IE0dT2LVsNmVjB34MvBVA0l9SOED6TF5BjqFS/ABvB+6NiP7cohtfpfgfB96ctHkr0KxDcJX+9ncDkNQB/DOwOscYa3UFhQJO8n55jrFMila/lUm5XsyjFIax7khGTuYDt0k6OCKenPwQK4uI7ZJOAq6lcFbKeRFxt6TvSTqQwi79w8B/zS/K8saI/QHgvOTg3Dbg+EhOS2kmleJPFi+nuYevxvr9/wH4RrIXtQVoyttqjBH/JyR9LGl2KfDvuQU5BknfB94CzJXUD5wGfInCkO1HKOShY/KLcHK09JXoyf8k9wNvA/5IoVdzXCoRIOlhYGlENGMv2MwsF5IWAf83IvYrmX8jhcsIxr03VksPYUXEdqDYi7kHuCRdPMzMbLRkD+qXwKsk9Uv6iKSjk72pNwI/kXTtuOtp5T0QMzPLT0vvgZiZWX5cQMzMLJOWLSCS5ku6PLlx2e8lfSM5HbBS+5MlTZ/MGM3M2llLFpDkyuZLgR9HxBIKt8+YCXxxjK+dDLiAmJnVSUseRJf0NuC0iPjr1LzZwB+AhcC/Au+kcB3FuRQuOPwqheekPxMRh0560GZmbaZVLyTcF1iXnhERz0l6FPgvwGLgtcnFSnMiYpOkTwKH+noQM7P6aMkhLAp7FOV2nUThPv2rk2tEiIjSWy6bmVkdtGoBuRsYcb/6ZAhrAZWLi5mZ1VGrFpAbgOmSPgTDzwX5GoV73F8HnJjc5gRJc5LvPE/h9tBmZlYHLVlAkpvzHQ0ck9y8734KN477J+B/U7iR2Z2S7gCOS762Brha0s9yCNnMrO205FlYZmaWv5bcAzEzs/y5gJiZWSYuIGZmlklLFBBJCyT9TNI9ku6W9Ilk/hxJ1yf3w7pe0s7J/F2S9i9IOie1nlmSbk+9npF0Vk7/LDOzltYSB9GTZ4TPi4jbJM2icBX6e4C/BzZFxJckrQJ2jojPSZoBvBbYD9gvIk6qsN51wCkRcfNk/DvMzNpJS+yBRMQTEXFbMv08hacP7knh2ecXJM0uoFBUiIgXI+IWCqf2liVpCbAb8PPGRW5m1r5aooCkJc/xfS3wK2D3iHgCCkWGQkGo1rHAxdEKu2BmZk2opQqIpJnAj4CTI+K5Ca5uOfD9iUdlZjY1tUwBkdRNoXhcFBGXJrOfSo6PFI+TbKhyXQcAXRGxbtzGZmZWVksUkOQBUt8F7omIr6cWXQEcn0wfD1xe5SqPxXsfZmYT0ipnYR1C4WD3XcBQMvufKBwHuYTCQ6QeBY4p3r5d0sPAbKAH+BPwjoj4XbLsIeCIiLh38v4VZmbtpSUKiJmZNZ+WGMIyM7Pm4wJiZmaZuICYmVkmLiBmZpaJC4iZmWXiAmKWgaTBkjs7r6rjuhdJWl+v9Zk1SlfeAZi1qM0RcWDeQZjlyXsgZnUk6WFJZ0r6dfL6i2T+XpJukHRn8r4wmb+7pMsk3ZG8/ipZVaekc5Pn31wnaVpu/yizClxAzLKZVjKE9f7Usuci4mDgHOCsZN45wIURsT9wEXB2Mv9s4KaIOAA4CLg7mb8E+FZE7EvhTgrvbei/xiwDX4luloGkFyJiZpn5DwNvjYiHkhuAPhkRu0h6hsJD0QaS+U9ExFxJTwPzI2Jrah2LgOsjYkny+XNAd0T8t0n4p5lVzXsgZvUXFaYrtSlna2p6EB+vtCbkAmJWf+9Pvf8ymf4FhWfQAPwdcEsyfQOwEkBSp6TZkxWk2US5V2OWzTRJt6c+XxMRxVN5eyX9ikIH7dhk3j8C50n6DPA0cEIy/xPAGkkfobCnsRJ4otHBm9WDj4GY1VFyDGRpRDyTdyxmjeYhLDMzy8R7IGZmlon3QMzMLBMXEDMzy8QFxMzMMnEBMTOzTFxAzMwsExcQMzPL5P8D71qiPX+/0SsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEeCAYAAABlggnIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAihElEQVR4nO3de5xdZX3v8c937gkTIiQhIiEGlZvSEjDmaCkaUapiy02pxEsp0aa1cgrYVqKecnnRo2CFQhXtKx6i6IlGT8GCHAUigtQeik0oIBgUxZSGhJCASAKZyVx+54+1ZmXPnr337Jk9e689M9/367Vfe+1nXfZvZpLnt57nWetZigjMzMwAWvIOwMzMmoeTgpmZZZwUzMws46RgZmYZJwUzM8s4KZiZWaYt7wCqMXfu3Fi0aFHeYZiZTSobN27cGRHzxrLPpEgKixYtYsOGDXmHYWY2qUj6z7Hu4+4jMzPLOCmYmVnGScHMzDJOCmZmlnFSMDOzjJOCmZllnBTMzCwzKe5TMDOb9AYHYbAP+nthoA8G9sJAwXJW3puu66tQtregvFRZujwOdUsKkrqAe4DO9Hv+KSIukXQg8E1gEbAZ+MOI+HW94jCzaWRwcHhl29+bLPfvTcv37isrrEyzSrXU8mgVeHFZ8XelZYPjq6QrammHtk5obYfWTmjtSJaHysahni2FXuCkiNgtqR34kaTvAWcCd0bEFZJWAauAi+oYh5lNtAgY7E8qvaziLapgq6p8R1vfN/zYA3vTCr6wou/dVzbYP7E/Z2vHyFdbibLOWTBzzujblSwbqtTLlRUsD0sA7SBVjv/PRllfQt2SQiTP+dydfmxPXwGcBixLy28A7sZJwayyiNIVbmEF2d8zsqxsZV10jP6e0Y9ffEwm8FG+Q5VfW3HFWLDc1gWd++8rL6wgh207VJEWLGfH7axyffoardKdguo6piCpFdgIvAq4LiLukzQ/IrYBRMQ2SQfVMwazcYsoOFMtqnSzSrSnoKLsGV5pFp9Fj1ge2r93+LEKK+jsbHrvxP1cWZdDR9F7QYXZMRNaDyioNEfZvq0jqbRHrOsYud2IyrmKM15rmLomhYgYABZLegnwbUnHVLuvpJXASoCFCxfWJ0BrXgP9+yrMrDLuHV5xZuuGPldaV65SH6XinpCzYSUVZltnQYXZOfxz+wyYcUBaqXYNr4xHVMBVVNCVtmvxRYdWXkOuPoqI5yTdDbwd2C7p4LSVcDDwdJl9VgOrAZYsWTKB7VSrKOsrLqhY+3uLlnuGn+WOuq5g/UDx9mXWxWDtP0trR+kKuK2gwpzZPbLizc54CyvnrpFnw9k+JSrxwu1a2nwmbJNGPa8+mgf0pQlhBvBW4ErgFuAc4Ir0/eZ6xTBpDQ4UVcpFFXTfnpEV8Yj3SutKbdszwRXyUGVZVKEOVaQd3TBz7vAKe1hl3FVhXWfR+hLrWjt8Rmw2DvVsKRwM3JCOK7QA34qIWyXdC3xL0geBJ4Cz6hjD+GXdFz1lKuM9JcrKbTvGSrrWKyjUAm0ziirPoveu2RXWF1fmMyhbuZeq+KfpAJ3ZVFDPq48eAo4rUf4M8JYxHWxwAHY9Vbqi7SuscAvW9/VUV1GX27/WinlEJVtU+WZnyV3QXmabqt5LlI3z+mQzs8lxR/NTD8FVR459v5b2fZVl+9DZbsFZ74wDYFbXyPJhlXTx/gXl7YWVctGZuc+UzWwSmhxJYfYC+P1LqqyoZ+zr2midHD+emVmzmBy15n7zYMmKvKMwM5vyfHmGmZllnBTMzCzjpGBmZhknBTMzyzgpmJlZxknBzMwyTgpmZpZxUjAzs4yTgpmZZZwUzMws46RgZmYZJwUzM8s4KZiZWcZJwczMMk4KZmaWcVIwM7OMk4KZmWWcFMzMLOOkYGZmmbolBUmHSrpL0iZJj0g6Py2/VNKTkh5IX6fUKwYzMxubtjoeux/4y4i4X9IsYKOk9em6v4+Iz9bxu83MbBzqlhQiYhuwLV3eJWkTcEi9vs/MzGrXkDEFSYuA44D70qLzJD0kaY2kAxoRg5mZja7uSUFSN3AjcEFEPA98EXglsJikJXFVmf1WStogacOOHTvqHaaZmVHnpCCpnSQhrI2ImwAiYntEDETEIPAlYGmpfSNidUQsiYgl8+bNq2eYZmaWqufVRwKuBzZFxNUF5QcXbHYG8HC9YjAzs7Gp59VHJwAfAH4i6YG07BPAckmLgQA2A39axxjMzGwM6nn10Y8AlVj13Xp9p5mZ1aaeLYUJ8/SuXr78r79iv842ZnW2sV9nG91dw5f362ijtaVUDjIzs2pNiqSw/fkeLvvOT0fdbmZHa5Y4hhJFd1cb3Z3Ja7/ONmZ17VseKk+2aaW7s53urjZmtrfS4gRjZtPQpEgKxxwymzsvPpldPf28sLef3T397Ort54XeZHl3b/J6IX3f1bNvecuv97C7ty/brm8gqvrOJHG0FiWOthGtle7OolfX8G1mdrSSjLmbmTW/SZEUBLxkZgcvmdlR87F6+wd4oXcgTSx9yXJvH7vTssLlLMmkCWfnrhezBLS7t5+BwdETTIso0Sop87loXWHLprurjc621pp/fjOzSiZFUphInW2tdLa1cuB+tSWYiKC3f3BYq6RwOXuVack89Zuefev39hNVNGDaW7WvNdIxvCusuFss+dzOfp2tw5fT97ZWT5BrZiNNu6QwUSTR1d5KV3sr82Z11nSswcFgT9/AiMQyWpLZ3dPPzt17+c9nXmRX+nlP30BV39nV3kJ3Zzuzugq7yQo/p8sdrXR3tWeJZnjScfeY2VTjpNAEWlrEfulZ/vz9aztW/8AgL+wdyFomu3oKWimFYzHFSaenn63P7RmWgPb2D476fRJ0dxSNuZQZ3C/VdTbUcnH3mFlzcFKYYtpaW5g9o4XZM9prPtbQ+Ethctnd25cmk4FsAL840ezu7Wf78z3Zut291XWPdbS2pAP1aUulYOC+u6iLbFZnmUTky5PNauKkYGVN5PjLnr6BfUkibaHsKu4OK9E9tmNXL7/a+UL2udrusZkdrQWtkYJLkLvahiWbfcmldBdZZ1uLu8dsWnFSsLqTxMyONmZ2tHFQjcfqHxjkhd6BYVeOFXaRZS2a9PLl53v2dZ098cK+q8d29VR39Vhbi8peMTar6F6YoQH94vtehvZz68UmAycFm1TaWluYPbOF2TNr6x4rd/XYUBdZ0mIZ3kU2lGh+/cJennj2xaxV8+Le6lovM9pbh7VUSl6aXLJl0z4s8bj1YvXkpGDT0kRePTYwGNlNlbuLWyvDusn60qQzwO6eZPmJZ18c1l3WX2XrpXicZXhrZeTlyCPWe+zFynBSMKtRa4vYv6ud/bsmpvVSOLYyrCVTmFyKBvjH23opHnvpLkgqhZcnZ+tLJKD9Ot16mUqcFMyaRGHrZW537a2XwpsmC1svheMwpQb6n9n9YkFXWnVjL4U3VhZeOVb+UuTSYzGedyx/TgpmU1Bri5g9o73mS5Mjgp6+wWFJY1fBXGKF3WWF98IMXTn2+I7d2dhMT9/Y7nsZ0UU2IqG0Vxyjafdd++PipGBmZUliRkcrMzpqH3vpGxjMWi2FE1vu7ilMOMPHX4YSznimhelsaylx42T7KDdTFg/6t9PVPr26xpwUzKwh2ltbJmRiy8HB4MW+gRH3tJTqFitOOk8+t2/W5F1VDuy3tihLHJUG9ksnlcn3zBcnBTObVFoKKulalBrYHz7I31fysuTdvf08+8JenhjHnGPJXGJDSaO97OD9iPGWonX17BpzUjCzaWkiB/Yr3VRZ6lLlfa2YPp7eNfYpYartGhsPJwUzsxpN5E2VL6YTWpZOKH0lu8V29Q6f0HJXT1/VDxQb8bPU9BOYmdmEkQpmTK7xWL39A3RdOfb9fM2WmdkUNN6p6OuWFCQdKukuSZskPSLp/LT8QEnrJT2Wvh9QrxjMzGxs6tlS6Af+MiKOBl4PfETSq4FVwJ0RcThwZ/rZzMyaQN2SQkRsi4j70+VdwCbgEOA04IZ0sxuA0+sVg5mZjU1VA81pF8/LgD3A5ogY/X714fsvAo4D7gPmR8Q2SBKHpFqn2DczswlSNilImg18BFgOdAA7gC5gvqR/A74QEXeN9gWSuoEbgQsi4vlqbxeXtBJYCbBw4cKq9jEzs9pUain8E/BV4MSIeK5whaTXAh+Q9IqIuL7cASS1kySEtRFxU1q8XdLBaSvhYODpUvtGxGpgNcCSJUvGd8GtmZmNSdmkEBEnV1i3EdhY6cBKmgTXA5si4uqCVbcA5wBXpO83jyVgMzOrn1EHmiWdIGm/dPn9kq6W9PIqjn0C8AHgJEkPpK9TSJLByZIeA05OP5uZWROoZqD5i8Cxko4FPkZy9v9V4E2VdoqIHwHlBhDeMpYgzcysMaq5JLU/IoLkUtJrI+JaYFZ9wzIzszxU01LYJenjwPuBN0pqBWqb9cnMzJpSNS2F9wC9wAcj4imSG9D+rq5RmZlZLirdp3A7cBvwvcKrhyLiCZIxBTMzm2IqdR+dA7wduFTSESR3I99GMm/R7kYEZ2bWCH19fWzZsoWenp68QxmXrq4uFixYQHt77T37le5TeAr4CvAVSS3AfwPeAXxM0h7gjoj4TM0RmJnlbMuWLcyaNYtFixZR7awLzSIieOaZZ9iyZQuHHXZYzcerakK8iBiMiHsj4uKIOAE4G3iy5m83M2sCPT09zJkzZ9IlBEgezDNnzpwJa+WMevWRpMOAvwBeXrh9RJw6IRGYmTWByZgQhkxk7NW0FP4Z+BXwOeCqgpeZmU2AZcuWcfvttw8ru+aaa/jzP//zhsdSTVLoiYh/iIi7IuKHQ6+6R2ZmNk0sX76cdevWDStbt24dy5cvb3gs1SSFayVdIukNko4fetU9MjOzaeLd7343t956K729vQBs3ryZrVu3snPnTt761rcSEWzbto0jjjiCp556qq6xVHNH82+RTmwHDD1cJ9LPZmZTymXfeYSfbn1+Qo/56pftzyV/8Jqy6+fMmcPSpUu57bbbOO2001i3bh3vec97OOOMM7jxxhu57rrruO2227jssst46UtfOqGxFasmKZwBvCIi9tY1EjOzaWyoC2koKaxZswaAz33ucxxzzDG8/vWvb0h3UjVJ4UHgJZR5GI6Z2VRS6Yy+nk4//XQ++tGPcv/997Nnzx6OPz7ppX/yySdpaWlh+/btDA4O0tJS1Z0E41bN0ecDj0q6XdItQ6+6RmVmNs10d3ezbNkyVqxYkbUI+vv7Offcc/n617/O0UcfzdVXXz3KUWpXTUvhkrpHYWZmLF++nDPPPDO7EulTn/oUJ554IieeeCKLFy/mda97He985zs5+uij6xZDNUlhZkR8r7BA0p8BvizVzGwCnXHGGSSPr0lcfPHF2fKsWbN49NFH6x5DNd1HfyMpu9JI0kUkD9wxM7MpppqWwqnArZL+mmTW1KPSMjMzm2JGTQoRsVPSqcD3gY3Au6OwfWNmZlNGpYfs7CK5SW1IB/AK4N2SIiL2r3dwZmbWWJWepzCrkYGYmVn+yg40S1pUaUclFlRYv0bS05IeLii7VNKTkh5IX6eMK2ozM6uLSlcf/Z2kGyX9kaTXSDpI0kJJJ0m6HPhXoNLFsl8hGZgu9vcRsTh9fbeG2M3MpoRJMXV2RJwF/A1wJHAd8C/AzcCHgJ8BJ0XE+gr73wM8O6HRmplNQZNm6uyI+GlEfDIilkXEkRFxXES8NyL+d0SM99lv50l6KO1eOmCcxzAzmzLKTZ29YsUKduzYAcDg4CCvetWr2LlzZ11jqeZxnBuANcDXI+K5Gr/vi8DlJFc1XU7yBLcVZb53JbASYOHChTV+rZlZlb63Cp76ycQe86W/Be+4ouzqclNnd3d3s3btWi644AK+//3vc+yxxzJ37tyJja1INXc0nw0cAmyQtE7S2zTOB4JGxPaIGIiIQeBLwNIK266OiCURsWTevHnj+Tozs0mjsAtpqOtoxYoVfPWrXwVgzZo1nHvuuXWPo5qb134BfFLS3wC/T9JqGJS0Brg2IqoeN5B0cERsSz+eATxcaXszs4arcEZfT+Wmzp4/fz4/+MEPuO+++1i7dm3d46hmmgsk/TZwLnAKcCOwFvhd4AfA4jL7fANYBsyVtIVkttVlkhaTdB9tBv60luDNzKaKUlNnA3zoQx/i/e9/Px/4wAdobW2texzVjClsBJ4DrgdWRURvuuo+SSeU2y8iSg2bXz+eIM3MpoPiqbMBTj31VM4999yGdB1BdS2FsyLi8cICSYdFxK8i4sw6xWVmNu0UT50N8OCDD3Lsscdy1FFHNSSGagaa/6nKMjMzm0BXXHEF73rXu/j0pz/dsO+sNCHeUcBrgNmSClsE+wNd9Q7MzGy6W7VqFatWrWrod1bqPjqS5GqjlwB/UFC+C/iTOsZkZmY5qTRL6s3AzZLeEBH3NjAmMzPLSaXuo49FxGeA90oacSVRRPxFXSMzM7OGq9R9tCl939CIQMzMLH+Vuo++k77f0LhwzMymn2XLlvHxj3+ct73tbVnZNddcw89//nO+8IUvNDSWUS9JlbRe0ksKPh8g6fYKu5iZ2RhMmqmzU/MKZ0eNiF8DB9UtIjOzaabc1Nl33HEHixcvZvHixRxyyCHNMSEeMCBpYUQ8ASDp5SRzF5mZTTlX/vhKHn320Qk95lEHHsVFSy8qu77c1NmXX345l19+Ob/5zW848cQTOe+88yY0rlKqaSl8EviRpK9J+hpwD/Dx+oZlZja9lJo6GyAieN/73seFF17Ia1/72rrHUc3U2bdJOh54fVp0YUTU99E/ZmY5qXRGX0/lps6+9NJLWbBgQVNNiAfwO8AbCz7fWodYzMymrVJTZ996662sX7+eu+++u2FxVHP10RXA+cBP09f5kho3O5OZ2TSxfPlyHnzwQc4++2wArrrqKrZu3crSpUtZvHgxF198cd1jqKalcAqwOH2EJpJuAP4DjyuYmU2o4qmz77rrrobHUM1AMyST4g2ZXYc4zMysCVTTUvg08B+S7gJEMrbgVoKZ2RRUzdVH35B0N/A6kqRwUUQ8Ve/AzMys8SrNknp8UdGW9P1lkl4WEffXLywzs8aKCCTlHca4FD/CsxaVWgpXVYoBOGnCojAzy1FXVxfPPPMMc+bMmXSJISJ45pln6OqamAdiVpol9c0T8g1mZk1uwYIFbNmyhR07duQdyrh0dXWxYMGCCTnWqGMKkmYCHwUWRsRKSYcDR0ZExRvYJK0heZzn0xFxTFp2IPBNYBGwGfjDdII9M7PctLe3c9hhh+UdRlOo5pLULwN7Se5qhmRs4W+r2O8rwNuLylYBd0bE4cCd6WczM2sS1SSFV6aP5ewDiIg9JFchVRQR9wDPFhWfBgw9tOcG4PSqIzUzs7qrJinslTSDdLpsSa8Eesf5ffMjYhtA+u7nMpiZNZGySUHS5yWdAFwK3AYcKmktSbfPx+odmKSVkjZI2jBZB3/MzCabSi2Fx4DPAquBXwLXAl8HlkTE3eP8vu2SDgZI358ut2FErI6IJRGxZN68eeP8OjMzG4uySSEiro2INwBvAn4GvIskSXxY0hHj/L5bgHPS5XOAm8d5HDMzq4NRxxQi4j8j4sqIOA54L3AmsGm0/SR9A7gXOFLSFkkfBK4ATpb0GHBy+tnMzJpENfcptJNcWno28Bbgh8Blo+0XEcvLrHrLWAI0M7PGqTT30cnAcuCdwI+BdcDKiHihQbGZmVmDVWopfIJkYPmvIqL4fgMzM5uCPPeRmZllqn3ympmZTQNOCmZmlnFSMDOzjJOCmZllnBTMzCzjpGBmZhknBTMzyzgpmJlZxknBzMwyTgpmZpZxUjAzs4yTgpmZZZwUzMws46RgZmYZJwUzM8s4KZiZWcZJwczMMk4KZmaWcVIwM7NM2Wc015OkzcAuYADoj4glecRhZmbD5ZIUUm+OiJ05fr+ZmRVx95GZmWXySgoB3CFpo6SVOcVgZmZF8uo+OiEitko6CFgv6dGIuKdwgzRZrARYuHBhHjGamU07ubQUImJr+v408G1gaYltVkfEkohYMm/evEaHaGY2LTU8KUjaT9KsoWXg94CHGx2HmZmNlEf30Xzg25KGvv/rEXFbDnGYmVmRhieFiHgcOLbR32tmZqPzJalmZpZxUjAzs4yTgpmZZZwUzMws46RgZmYZJwUzM8s4KZiZWcZJwczMMk4KZmaWcVIwM7OMk4KZmWWcFMzMLOOkYGZmGScFMzPLOCmYmVnGScHMzDJOCmZmlnFSMDOzjJOCmZllnBTMzCzjpGBmZhknBTMzy+SSFCS9XdLPJP1C0qo8YjAzs5EanhQktQLXAe8AXg0sl/TqRsdhZmYj5dFSWAr8IiIej4i9wDrgtBziMDOzInkkhUOA/yr4vCUtMzOznOWRFFSiLEZsJK2UtEHShh07djQgLDMzyyMpbAEOLfi8ANhavFFErI6IJRGxZN68eQ0LzsxsOssjKfw7cLikwyR1AGcDt+QQh5mZFWlr9BdGRL+k84DbgVZgTUQ80ug4zMxspIYnBYCI+C7w3Ty+28zMyvMdzWZmlsmlpTBWgzHInv49AESMuFBpmCi4kKl426D851GPW7C+0nFG27aa7Wrev9pjBSXXVfs7jOEHKL9dlceo9DcYy++4XFzV/l6qianqn6+Kv+V4fj9V/Yw1xFHNvhMVQy1/r6Hlsf6davkbj/Xfb83/T8cQf6X6olqTIilsenYTS9cuzTsMM7Mpb1Ikhfkz53Phay/MPqvoVocRn1XqVojRt52o4xSvH7Zc6ZhlYqm0f3Ecox6rxv0rHW/EsUTZddUeQ8MPUv4YVf5dq/2bVvO3qPjzjeNvOeZYKv3uxxlHNT9fs8Yw1r9TLX+jsf59xrxvNcepYt9Zfzyr5L6VTIqkMHfGXFYcsyLvMMzMpjwPNJuZWcZJwczMMk4KZmaWcVIwM7OMk4KZmWWcFMzMLOOkYGZmGScFMzPLaLQ5f5qBpF3Az/KOowazgd/kHUQNJnP8kzl2cPx5m+zxHxkRY7qteVLc0Qz8LCKW5B3EeElaHREr845jvCZz/JM5dnD8eZsC8W8Y6z7uPmqM7+QdQI0mc/yTOXZw/Hmb7PGP2WTpPtowmVsKZmZ5GE/dOVlaCqvzDsDMbBIac905KZJCREyapCDp7ZJ+JukXklalZZdKelLSA+nrlLzjLKdU/Gn5f0/LH5H0mTxjrKTM7/+bBb/7zZIeyDnMssrEv1jSv6Xxb5DUlA8XKRP7sZLulfQTSd+RtH/ecZYjaY2kpyU9XFB2oKT1kh5L3w/IM8axGlfdGRF+TdALaAV+CbwC6AAeBF4NXAr8Vd7x1RD/m4HvA53pdgflHetY4i/a5irg4rxjHePv/w7gHek2pwB35x3rGGL/d+BN6TYrgMvzjrXCz/BG4Hjg4YKyzwCr0uVVwJV5x1nvV9O1FMqdqabr/kpSSJqbV3yjWAr8IiIej4i9wDrgtJxjGoty8X8YuCIiegEi4ukcY6yk4u9fyVNJ/hD4Rk7xjaZc/AEMnWHPBrbmFF8l5WI/Ergn3WY98K6c4htVRNwDPFtUfBpwQ7p8A3B6I2OqVplWzllpy35QUtXjCk2VFCS1AtcB7yA5y1gu6dXpukOBk4En8otwVIcA/1XweUtaBnCepIfSP16zNkHLxX8EcKKk+yT9UNLrcoludJV+/wAnAtsj4rGGRlW9cvFfAPydpP8CPgt8vPGhjapc7A8Dp6ZlZwGHNjiuWs2PiG0A6ftBOcdTzleAtxeVPQycyb6kXJWmSgpUPtP7e+BjjHhEfFMp9dy8AL4IvBJYDGwj6cJoRuXibwMOAF4P/DXwLVV6lmR+ysU/ZDnN20qA8vF/GLgwIg4FLgSub2hU1SkX+wrgI5I2ArOAvQ2Napoo1cqJiE0RMeabfpstKZQ825B0KvBkRDyYT1hV28LwM6EFwNaI2B4RAxExCHyJJPk1o5Lxp+U3ReLHwCDQjF145eJHUhvJWdM3c4irWuXiPwe4KS37PzTnv59y//YfjYjfi4jXkiTkX+YS3fhtl3QwQPrerF2nE6bZkkKps41O4JPAxQ2OZTz+HThc0mGSOoCzgVuG/lGlziBp1jWjkvED/wycBCDpCJKBxJ15BVlBufgB3go8GhFbcotudOXi3wq8Kd3mJKAZu7/K/ds/CEBSC/A/gH/MMcbxuIUkKZO+35xjLA3RbNNclDrbeIKkC+nBtMdiAXC/pKUR8VTjQywvIvolnQfcTnI1xpqIeETS1yQtJmlObwb+NL8oy6sQ/2PAmnQQay9wTqSXYzSTcvGnq8+mubuOKv3+/wS4Nm3t9ABNN+1ChdjPl/SRdLObgC/nFuQoJH0DWAbMlbQFuAS4gqS79IMkddFZ+UXYGE11R3P6j/7nwFuAJ0nOPt5b8B8bSZuBJRHRjGeqZma5kLQIuDUijikqv5vkkviq5kFqqu6jiOgHhs42NgHfKkwIZmY2UtrKuRc4UtIWSR+UdEba4nkD8H8l3V7VsZqppWBmZvlqqpaCmZnly0nBzMwyTZMUJC2QdHM68dQvJV2bXtpWbvsLJM1sZIxmZlNdUySF9O7Ym4B/jojDSaZV6Ab+Z4XdLgCcFMzMJlBTDDRLegtwSUS8saBsf+BXwELgMuBtJNf5f4nkJrfPkjy3eWdEvLnhQZuZTUHNcvPaa4CNhQUR8bykJ4APAYcBx6U3yBwYEc9K+ijwZt+vYGY2cZqi+4jkzL9Uk0Ukc5z/Y3oPAxFRPLWtmZlNkGZJCo8Aw+b7TruPDqV8wjAzswnWLEnhTmCmpD+C7LkKV5HMEX4H8GfpFBhIOjDdZxfJVLxmZjZBmiIppJOrnQGclU6+9nOSib8+AfwvkomoHpL0IPDedLfVwPck3ZVDyGZmU1JTXH1kZmbNoSlaCmZm1hycFMzMLOOkYGZmmVySgqRDJd0laZOkRySdn5YfKGl9Ov/RekkHpOVz0u13S/p8wXFmSXqg4LVT0jV5/ExmZlNBLgPN6TOLD46I+yXNIrmb+XTgj4FnI+IKSauAAyLiIkn7AccBxwDHRMR5ZY67EbgwIu5pxM9hZjbV5NJSiIhtEXF/uryL5Clrh5A8i/mGdLMbSBIFEfFCRPyI5DLVkiQdDhwE/Ev9Ijczm9pyH1NInyt6HHAfMD8itkGSOEgq+WotB77ZjA+UNzObLHJNCpK6gRuBCyLi+RoPdzbwjdqjMjObvnJLCpLaSRLC2oi4KS3eno43DI07PF3lsY4F2iJi46gbm5lZWXldfSTgemBTRFxdsOoW4Jx0+Rzg5ioPuRy3EszMapbX1Ue/SzIg/BNgMC3+BMm4wrdIHqzzBHDW0FTZkjYD+wMdwHPA70XET9N1jwOnRMSjjfspzMymHs99ZGZmmdyvPjIzs+bhpGBmZhknBTMzyzgpmJlZxknBzMwyTgpmgKSBohl3V03gsRdJeniijmdWT215B2DWJPZExOK8gzDLm1sKZhVI2izpSkk/Tl+vSstfLulOSQ+l7wvT8vmSvi3pwfT1O+mhWiV9KX1+yB2SZuT2Q5lV4KRglphR1H30noJ1z0fEUuDzwDVp2eeBr0bEbwNrgX9Iy/8B+GFEHAscDzySlh8OXBcRryG5I/9ddf1pzMbJdzSbAZJ2R0R3ifLNwEkR8Xg6ieNTETFH0k6SB0X1peXbImKupB3AgojoLTjGImB9RByefr4IaI+Iv23Aj2Y2Jm4pmI0uyiyX26aU3oLlATyeZ03KScFsdO8peL83Xf5/JM/wAHgf8KN0+U7gwwCSWiXt36ggzSaCz1bMEjMkPVDw+baIGLostVPSfSQnUcvTsr8A1kj6a2AHcG5afj6wWtIHSVoEHwa21Tt4s4niMQWzCtIxhSURsTPvWMwawd1HZmaWcUvBzMwybimYmVnGScHMzDJOCmZmlnFSMDOzjJOCmZllnBTMzCzz/wF66P9eH/ZrLQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "eph = batch_run.get_result_ephemeris(2)\n",
+    "print (eph.values[0])\n",
+    "eph.plot(x='Epoch', y=['X','Y','Z'], ylabel='Position(km)')\n",
+    "eph.plot(x='Epoch', y=['Vx','Vy','Vz'], ylabel=\"Velocity(km/s)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Get Raw Ephemeris Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "stk.v.11.0\n",
+      "BEGIN Ephemeris\n",
+      "ScenarioEpoch 04 Oct 2017 00:00:00.000000\n",
+      "CentralBody SUN\n",
+      "CoordinateSystem ICRF\n",
+      "InterpolationMethod HERMITE\n",
+      "InterpolationOrder 5\n",
+      "NumberOfEphemerisPoints 8\n",
+      "\n",
+      "EphemerisTimePosVel\n",
+      "0.000000000000e+00 1.303475601335e+11 -7.440728759304e+10 -3.524759853804e+10 2.393524884363e+04 2.714629132829e+04 1.034657518873e+04\n",
+      "8.640000000000e+04 1.323979017940e+11 -7.205192283917e+10 -3.434894303687e+10 2.352586222700e+04 2.737450360283e+04 1.045501952587e+04\n",
+      "1.728000000000e+05 1.344127479740e+11 -6.967723942427e+10 -3.344107796102e+10 2.311365770293e+04 2.759347848765e+04 1.055975587902e+04\n",
+      "2.592000000000e+05 1.363918716097e+11 -6.728403626072e+10 -3.252432458741e+10 2.269901429550e+04 2.780320032640e+04 1.066076447235e+04\n",
+      "3.456000000000e+05 1.383350781923e+11 -6.487311286780e+10 -3.159900558744e+10 2.228230639228e+04 2.800367063803e+04 1.075803277155e+04\n",
+      "4.320000000000e+05 1.402422053215e+11 -6.244526791166e+10 -3.066544440957e+10 2.186390268296e+04 2.819490755279e+04 1.085155528864e+04\n",
+      "5.184000000000e+05 1.421131221696e+11 -6.000129779665e+10 -2.972396467993e+10 2.144416516878e+04 2.837694518753e+04 1.094133335939e+04\n",
+      "6.048000000000e+05 1.439477288638e+11 -5.754199531307e+10 -2.877488962330e+10 2.102344824655e+04 2.854983296777e+04 1.102737489607e+04\n",
+      "\n",
+      "\n",
+      "END Ephemeris\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "ephem_raw_data = batch_run.get_result_raw_ephemeris(2)\n",
+    "print(ephem_raw_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get ending state vector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Close State Vectors\n",
+      "None\n",
+      "Impact State Vectors\n",
+      "None\n",
+      "Miss State Vectors\n",
+      "First miss end state: [1610537328.1226196, -99035107564.6815, -46761965680.43153]\n"
+     ]
+    }
+   ],
+   "source": [
+    "end_state_vectors = batch_run.get_final_positions(BatchPropagationResults.PositionOrbitType.CLOSE_APPROACH)\n",
+    "print(\"Close State Vectors\")\n",
+    "if len(end_state_vectors) > 0:\n",
+    "    print(f'First close end state: {end_state_vectors[0]}')\n",
+    "else:\n",
+    "    print(\"None\")\n",
+    "\n",
+    "\n",
+    "end_state_vectors = batch_run.get_final_positions(BatchPropagationResults.PositionOrbitType.IMPACT)\n",
+    "print(\"Impact State Vectors\")\n",
+    "if len(end_state_vectors) > 0:\n",
+    "    print(f'First impact end state: {end_state_vectors[0]}')\n",
+    "else:\n",
+    "    print(\"None\")\n",
+    "\n",
+    "\n",
+    "end_state_vectors = batch_run.get_final_positions(BatchPropagationResults.PositionOrbitType.MISS)\n",
+    "print(\"Miss State Vectors\")\n",
+    "if len(end_state_vectors) > 0:\n",
+    "    print(f'First miss end state: {end_state_vectors[0]}')\n",
+    "else:\n",
+    "    print(\"None\")\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ flake8
 jupyter
 pyxdg
 pyyaml
+matplotlib


### PR DESCRIPTION
This commit implements:

- ICRF to JPL Ecliptic (and back) frame tranformations
- STK Ephemeris parser
- Updated the `get_result_ephemeris` to return a Pandas DataFrame not the raw Ephemeris File
- Add a `get_result_raw_ephemeris` method to return the raw ephemeris 
- Add a `get_job_results` to return the results object (same object returned when submitting a new run)