### PR TITLE
Fixes errors for Locust GitHub Action

### DIFF
--- a/.github/workflows/locust.yml
+++ b/.github/workflows/locust.yml
@@ -1,14 +1,21 @@
 name: Locust summary
 
-on: [pull_request]
+on: [ pull_request_target ]
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
+      - name: PR head repo
+        id: head_repo_name
+        run: |
+          HEAD_REPO_NAME=$(jq -r '.pull_request.head.repo.full_name' "$GITHUB_EVENT_PATH")
+          echo "PR head repo: $HEAD_REPO_NAME"
+          echo "::set-output name=repo::$HEAD_REPO_NAME"
       - name: Checkout git repo
         uses: actions/checkout@v2
         with:
+          repository: ${{ steps.head_repo_name.outputs.repo }}
           fetch-depth: 0
       - name: Generate Locust summary
         uses: simiotics/locust-action@main


### PR DESCRIPTION
GitHub Actions triggered by `pull_request` events from forks do not have
permission to post comments to the base repo.

The fix for this is to use the `pull_request_target` event.

See official GitHub statement about `pull_request_target`:
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks