### PR TITLE
Added "Run status: complete" message in batch run

### DIFF
--- a/adam/batch_run_manager.py
+++ b/adam/batch_run_manager.py
@@ -216,3 +216,4 @@ class BatchRunManager(object):
         self._submit()
         self._wait_for_completion()
         self._get_results()
+        print("Run status: complete")

--- a/adam/batch_run_manager.py
+++ b/adam/batch_run_manager.py
@@ -216,4 +216,4 @@ class BatchRunManager(object):
         self._submit()
         self._wait_for_completion()
         self._get_results()
-        print("Run status: complete")
+        print(f"Run status: {self.state.name}")


### PR DESCRIPTION
Resolves https://github.com/B612-Asteroid-Institute/adam_home/issues/105

Used `print` because the timer itself uses `print`.