### PR TITLE
Set Locust to publish summaries on PR open events

### DIFF
--- a/.github/workflows/locust.yml
+++ b/.github/workflows/locust.yml
@@ -1,6 +1,8 @@
 name: Locust summary
 
-on: [ pull_request_target ]
+on:
+  pull_request_target:
+    types: [opened, reopened]
 
 jobs:
   build:


### PR DESCRIPTION
This means that Locust will not publish new summaries every time someone
synchronizes a PR (e.g. by pushing to its head branch).

This is a temporary workaround to:
https://github.com/bugout-dev/locust/issues/33