### PR TITLE
Up the wait time between status checks to 10s

### DIFF
--- a/adam/adam_processing_service.py
+++ b/adam/adam_processing_service.py
@@ -47,7 +47,7 @@ class ApsResults:
             str: the job status.
         """
 
-        sleep_time_sec = 1.0
+        sleep_time_sec = 10.0
         t0 = time.perf_counter()
         status = self.check_status()
         last_status = ''


### PR DESCRIPTION
Some users who are using the `wait_for_complete()` have reported "connnection reset" and "connection closed" errors.

Before trying to code around the problem, I'd like to try to Increase the wait time between each poll, from the client side, to see if the connection reset errors persist.

Eventually, we probably need to put in rate limiting on the client side. There are changes to make on the server side, but I will not discuss them here.