### PR TITLE
Make ephemeris_file_data_to_dataframe importable

### DIFF
--- a/adam/stk/io.py
+++ b/adam/stk/io.py
@@ -9,8 +9,14 @@ from adam.astro_utils import icrf_to_jpl_ecliptic
 STK_VERSION = "11.1"
 VERBOSE = True
 
-__all__ = ["createVectorFile", "createSensorFile", "createIntervalFile",
-           "convertPointingsToSensorInterval", "convertPointingsToVectorInterval"]
+__all__ = [
+    "createVectorFile",
+    "createSensorFile", 
+    "createIntervalFile",
+    "convertPointingsToSensorInterval", 
+    "convertPointingsToVectorInterval",
+    "ephemeris_file_data_to_dataframe"
+]
 
 
 def createVectorFile(fileName, exposureStart, exposureEnd,


### PR DESCRIPTION
[adam/stk/io.py](https://github.com/B612-Asteroid-Institute/adam_home/blob/master/adam/stk/io.py) was missing the ephemeris_file_data_to_dataframe function in the definition of `__all__` causing the function to not be importable via `from adam.stk import ephemeris_file_data_to_dataframe`. We could also remove the `__all__` definition altogether. 